### PR TITLE
Update dmtxread.c : corners to stdout

### DIFF
--- a/dmtxread/dmtxread.c
+++ b/dmtxread/dmtxread.c
@@ -633,10 +633,10 @@ PrintStats(DmtxDecode *dec, DmtxRegion *reg, DmtxMessage *msg,
       fprintf(stderr, "%d:", imgPageIndex + 1);
 
    if(opt->corners == DmtxTrue) {
-      fprintf(stderr, "%d,%d:", (int)(p00.X + 0.5), height - 1 - (int)(p00.Y + 0.5));
-      fprintf(stderr, "%d,%d:", (int)(p10.X + 0.5), height - 1 - (int)(p10.Y + 0.5));
-      fprintf(stderr, "%d,%d:", (int)(p11.X + 0.5), height - 1 - (int)(p11.Y + 0.5));
-      fprintf(stderr, "%d,%d:", (int)(p01.X + 0.5), height - 1 - (int)(p01.Y + 0.5));
+      fprintf(stdout, "%d,%d:", (int)(p00.X + 0.5), height - 1 - (int)(p00.Y + 0.5));
+      fprintf(stdout, "%d,%d:", (int)(p10.X + 0.5), height - 1 - (int)(p10.Y + 0.5));
+      fprintf(stdout, "%d,%d:", (int)(p11.X + 0.5), height - 1 - (int)(p11.Y + 0.5));
+      fprintf(stdout, "%d,%d:", (int)(p01.X + 0.5), height - 1 - (int)(p01.Y + 0.5));
    }
 
    return DmtxPass;


### PR DESCRIPTION
I used to get datamatrix position (--corners option) along with the message on the same line, as in old (at least 2007 ... wow!) versions of dmtxread.

Recently (when ?) the corners positions were returned via stderr instead of stdout. This did no easily allow to rebuild the links positions/message.

This pull request sends corners positions to stdout.

This is conform to the option --corners where positions are expected to prefix the message